### PR TITLE
Harden GitHub workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,5 @@
 version: 2
 updates:
-  # Maintain dependencies for GitHub Actions.
 
   # Maintain dependencies for Composer
   - package-ecosystem: "composer"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,8 @@
 version: 2
 updates:
-  # Maintain dependencies for GitHub Actions.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
-    # Too noisy. See https://github.community/t/increase-if-necessary-for-github-actions-in-dependabot/179581
-    open-pull-requests-limit: 0
-
-  # Maintain dependencies for Composer
-  - package-ecosystem: "composer"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    versioning-strategy: increase-if-necessary
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     open-pull-requests-limit: 0
 
   # Maintain dependencies for Composer
+    ignore:
+      - dependency-name: "yiisoft/*"
   - package-ecosystem: "composer"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,11 @@
 version: 2
 updates:
+  # Maintain dependencies for GitHub Actions.
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    versioning-strategy: increase-if-necessary
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,8 @@
 version: 2
 updates:
   # Maintain dependencies for GitHub Actions.
+
+  # Maintain dependencies for Composer
   - package-ecosystem: "composer"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,5 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    ignore:
+      - dependency-name: "yiisoft/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,4 +15,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
     versioning-strategy: increase-if-necessary

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,5 @@
 version: 2
 updates:
-
   # Maintain dependencies for Composer
   - package-ecosystem: "composer"
     directory: "/"

--- a/.github/workflows/composer-require-checker.yml
+++ b/.github/workflows/composer-require-checker.yml
@@ -24,9 +24,12 @@ on:
 
 name: Composer require checker
 
+permissions:
+  contents: read
+
 jobs:
   composer-require-checker:
-    uses: yiisoft/actions/.github/workflows/composer-require-checker.yml@master
+    uses: yiisoft/actions/.github/workflows/composer-require-checker.yml@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
     with:
       os: >-
         ['ubuntu-latest']

--- a/.github/workflows/composer-require-checker.yml
+++ b/.github/workflows/composer-require-checker.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   composer-require-checker:
-    uses: yiisoft/actions/.github/workflows/composer-require-checker.yml@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
+    uses: yiisoft/actions/.github/workflows/composer-require-checker.yml@master
     with:
       os: >-
         ['ubuntu-latest']

--- a/.github/workflows/mssql.yml
+++ b/.github/workflows/mssql.yml
@@ -15,6 +15,9 @@ on:
       - 'composer.json'
       - 'phpunit.xml.dist'
 name: mssql
+
+permissions:
+  contents: read
 jobs:
   tests:
     permissions:
@@ -89,13 +92,15 @@ jobs:
           dpkg -l | grep msodbcsql
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
 
       - name: Create MS SQL Database
         run: docker exec -i mssql ${{ matrix.mssql.tools-path }}/bin/sqlcmd ${{ matrix.mssql.flag }} -S localhost -U SA -P 'YourStrong!Passw0rd' -Q 'CREATE DATABASE yiitest'
 
       - name: Install PHP with extensions
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45
         with:
           php-version: ${{ matrix.php }}
           extensions: ${{ env.extensions }}
@@ -107,7 +112,7 @@ jobs:
         run: echo "COMPOSER_CACHE_DIR=$(composer config cache-dir)" >> $GITHUB_ENV
 
       - name: Cache dependencies installed with composer
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: ${{ env.COMPOSER_CACHE_DIR }}
           key: php${{ matrix.php }}-composer-${{ hashFiles('**/composer.json') }}
@@ -131,7 +136,7 @@ jobs:
           CYCLE_MSSQL_PASSWORD: YourStrong!Passw0rd
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml

--- a/.github/workflows/mssql.yml
+++ b/.github/workflows/mssql.yml
@@ -16,13 +16,17 @@ on:
       - 'phpunit.xml.dist'
 name: mssql
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 jobs:
   tests:
     permissions:
       contents: read
-      pull-requests: write
+      pull-requests: write # Required by Codecov to add pull request coverage comments.
     name: PHP ${{ matrix.php }}-mssql-${{ matrix.mssql.server }}
     env:
       extensions: pdo, pdo_sqlsrv-5.12
@@ -38,6 +42,7 @@ jobs:
 
         mssql:
           - server: 2022-latest
+            image: mcr.microsoft.com/mssql/server:2022-latest@sha256:e07b9699a2b749969f19d86563ceeea22bd3a69f7f1db85a8d1ac4bdaf0c6f56
             odbc-version: 18
             flag: "-C"
             tools-path: "/opt/mssql-tools18"
@@ -46,6 +51,7 @@ jobs:
           - php: 8.3
             mssql:
               server: 2017-latest
+              image: mcr.microsoft.com/mssql/server:2017-latest@sha256:0773d9c39ee51fdd581ed8119f5a29b3eab875d193b98ffd8f1d56a99de1eac8
               odbc-version: 17
               flag: ""
               tools-path: "/opt/mssql-tools"
@@ -53,13 +59,14 @@ jobs:
           - php: 8.3
             mssql:
               server: 2019-latest
+              image: mcr.microsoft.com/mssql/server:2019-latest@sha256:5b89fce40832a459ad4d634e9d588ae1e4496e664d9a4a9f8baeed6949b53fef
               odbc-version: 18
-              flag: "-C"    
+              flag: "-C"
               tools-path: "/opt/mssql-tools18"
 
     services:
       mssql:
-        image: mcr.microsoft.com/mssql/server:${{ matrix.mssql.server }}
+        image: ${{ matrix.mssql.image }}
         env:
           SA_PASSWORD: YourStrong!Passw0rd
           ACCEPT_EULA: Y
@@ -69,19 +76,24 @@ jobs:
         options: --name=mssql --health-cmd="${{ matrix.mssql.tools-path }}/bin/sqlcmd ${{ matrix.mssql.flag }} -S localhost -U SA -P 'YourStrong!Passw0rd' -Q 'SELECT 1'" --health-interval=10s --health-timeout=5s --health-retries=3
     steps:
       - name: Install ODBC driver.
+        env:
+          ODBC_VERSION: ${{ matrix.mssql.odbc-version }}
         run: |
           curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | sudo tee /usr/share/keyrings/microsoft-prod.gpg > /dev/null
-          curl -fsSL https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/prod.list | sudo tee /etc/apt/sources.list.d/mssql-release.list
+          . /etc/os-release
+          echo "deb [arch=amd64,arm64,armhf signed-by=/usr/share/keyrings/microsoft-prod.gpg] https://packages.microsoft.com/ubuntu/${VERSION_ID}/prod ${VERSION_CODENAME} main" | sudo tee /etc/apt/sources.list.d/mssql-release.list
           sudo apt-get update
-          sudo ACCEPT_EULA=Y apt-get install -y msodbcsql${{ matrix.mssql.odbc-version }}
+          sudo ACCEPT_EULA=Y apt-get install -y "msodbcsql${ODBC_VERSION}"
 
       - name: Verify ODBC driver installation
+        env:
+          ODBC_VERSION: ${{ matrix.mssql.odbc-version }}
         run: |
           echo "=== Installed ODBC Drivers ==="
           odbcinst -q -d
           echo ""
-          echo "=== Expected Driver: ODBC Driver ${{ matrix.mssql.odbc-version }} for SQL Server ==="
-          if odbcinst -q -d -n "ODBC Driver ${{ matrix.mssql.odbc-version }} for SQL Server"; then
+          echo "=== Expected Driver: ODBC Driver ${ODBC_VERSION} for SQL Server ==="
+          if odbcinst -q -d -n "ODBC Driver ${ODBC_VERSION} for SQL Server"; then
             echo "✓ Correct driver version installed!"
           else
             echo "✗ Expected driver not found!"
@@ -92,15 +104,23 @@ jobs:
           dpkg -l | grep msodbcsql
 
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 
       - name: Create MS SQL Database
-        run: docker exec -i mssql ${{ matrix.mssql.tools-path }}/bin/sqlcmd ${{ matrix.mssql.flag }} -S localhost -U SA -P 'YourStrong!Passw0rd' -Q 'CREATE DATABASE yiitest'
+        env:
+          MSSQL_SQLCMD_FLAG: ${{ matrix.mssql.flag }}
+          MSSQL_TOOLS_PATH: ${{ matrix.mssql.tools-path }}
+        run: |
+          sqlcmd=("${MSSQL_TOOLS_PATH}/bin/sqlcmd")
+          if [ -n "$MSSQL_SQLCMD_FLAG" ]; then
+            sqlcmd+=("$MSSQL_SQLCMD_FLAG")
+          fi
+          docker exec -i mssql "${sqlcmd[@]}" -S localhost -U SA -P 'YourStrong!Passw0rd' -Q 'CREATE DATABASE yiitest'
 
       - name: Install PHP with extensions
-        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: ${{ matrix.php }}
           extensions: ${{ env.extensions }}
@@ -112,7 +132,7 @@ jobs:
         run: echo "COMPOSER_CACHE_DIR=$(composer config cache-dir)" >> $GITHUB_ENV
 
       - name: Cache dependencies installed with composer
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ${{ env.COMPOSER_CACHE_DIR }}
           key: php${{ matrix.php }}-composer-${{ hashFiles('**/composer.json') }}
@@ -136,7 +156,7 @@ jobs:
           CYCLE_MSSQL_PASSWORD: YourStrong!Passw0rd
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457
+        uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457 # v3.1.6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -20,9 +20,12 @@ on:
 
 name: mutation test
 
+permissions:
+  contents: read
+
 jobs:
   mutation:
-    uses: yiisoft/actions/.github/workflows/roave-infection.yml@master
+    uses: yiisoft/actions/.github/workflows/roave-infection.yml@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
     with:
       os: >-
         ['ubuntu-latest']

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
   mutation:
-    uses: yiisoft/actions/.github/workflows/roave-infection.yml@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
+    uses: yiisoft/actions/.github/workflows/roave-infection.yml@master
     with:
       os: >-
         ['ubuntu-latest']

--- a/.github/workflows/mysql.yml
+++ b/.github/workflows/mysql.yml
@@ -22,12 +22,16 @@ on:
 
 name: mysql
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
 jobs:
   tests:
-    name: PHP ${{ matrix.php }}-mysql-${{ matrix.mysql }}
+    name: PHP ${{ matrix.php }}-mysql-${{ matrix.mysql.version }}
 
     env:
       extensions: pdo, pdo_mysql
@@ -47,12 +51,14 @@ jobs:
           - 8.5
 
         mysql:
-          - 5.7
-          - latest
+          - version: 5.7
+            image: mysql:5.7@sha256:dab0a802b44617303694fb17d166501de279c3031ddeb28c56ecf7fcab5ef0da
+          - version: latest
+            image: mysql:latest@sha256:55e529b57e06b3da98df40600de2245a0ab4bb4b979e3ead4339349b0b50bf4a
 
     services:
       mysql:
-        image: mysql:${{ matrix.mysql }}
+        image: ${{ matrix.mysql.image }}
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: true
           MYSQL_PASSWORD: ''
@@ -63,12 +69,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           persist-credentials: false
 
       - name: Install PHP with extensions
-        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: ${{ matrix.php }}
           extensions: ${{ env.extensions }}
@@ -80,7 +86,7 @@ jobs:
         run: echo "COMPOSER_CACHE_DIR=$(composer config cache-dir)" >> $GITHUB_ENV
 
       - name: Cache dependencies installed with composer
-        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
         with:
           path: ${{ env.COMPOSER_CACHE_DIR }}
           key: php${{ matrix.php }}-composer-${{ hashFiles('**/composer.json') }}
@@ -105,6 +111,6 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.os == 'ubuntu-latest'
-        uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457
+        uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457 # v3.1.6
         with:
           files: ./coverage.xml

--- a/.github/workflows/mysql.yml
+++ b/.github/workflows/mysql.yml
@@ -22,6 +22,9 @@ on:
 
 name: mysql
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: PHP ${{ matrix.php }}-mysql-${{ matrix.mysql }}
@@ -60,10 +63,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+        with:
+          persist-credentials: false
 
       - name: Install PHP with extensions
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45
         with:
           php-version: ${{ matrix.php }}
           extensions: ${{ env.extensions }}
@@ -75,7 +80,7 @@ jobs:
         run: echo "COMPOSER_CACHE_DIR=$(composer config cache-dir)" >> $GITHUB_ENV
 
       - name: Cache dependencies installed with composer
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c
         with:
           path: ${{ env.COMPOSER_CACHE_DIR }}
           key: php${{ matrix.php }}-composer-${{ hashFiles('**/composer.json') }}
@@ -100,6 +105,6 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.os == 'ubuntu-latest'
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457
         with:
           files: ./coverage.xml

--- a/.github/workflows/pgsql.yml
+++ b/.github/workflows/pgsql.yml
@@ -22,12 +22,16 @@ on:
 
 name: pgsql
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
 jobs:
   tests:
-    name: PHP ${{ matrix.php }}-pgsql-${{ matrix.pgsql }}
+    name: PHP ${{ matrix.php }}-pgsql-${{ matrix.pgsql.version }}
 
     env:
       extensions: pdo, pdo_pgsql
@@ -47,16 +51,22 @@ jobs:
           - 8.5
 
         pgsql:
-          - 9
-          - 10
-          - 11
-          - 12
-          - 13
-          - 14
+          - version: 9
+            image: postgres:9@sha256:15055f7b681334cbf0212b58e510148b1b23973639e3904260fb41fa0761a103
+          - version: 10
+            image: postgres:10@sha256:7a484b11fcabd39596b1bf08780cdb61fa9b0d8bfad0844dbdce3a6922df95d1
+          - version: 11
+            image: postgres:11@sha256:fdfb434d69d7884d6366840279dc3e721d1bd67cc1d02d51aeea7497f323fc5e
+          - version: 12
+            image: postgres:12@sha256:4bf4eb8e5932534db5fb9d3d91a212a91406aecf1fa626a60df4a9e2781d73ae
+          - version: 13
+            image: postgres:13@sha256:1094e2cdc5605e5c7914633bcd93758a9c52ae8c8b2855ddd1c3a8afbe4795d5
+          - version: 14
+            image: postgres:14@sha256:e49f970414656e9198612493a9a63eafffc780789b5ae636f9c077acc0410bd8
 
     services:
       postgres:
-        image: postgres:${{ matrix.pgsql }}
+        image: ${{ matrix.pgsql.image }}
         env:
           POSTGRES_USER: root
           POSTGRES_PASSWORD: root
@@ -67,12 +77,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           persist-credentials: false
 
       - name: Install PHP with extensions
-        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: ${{ matrix.php }}
           extensions: ${{ env.extensions }}
@@ -85,7 +95,7 @@ jobs:
         run: echo "COMPOSER_CACHE_DIR=$(composer config cache-dir)" >> $GITHUB_ENV
 
       - name: Cache dependencies installed with composer
-        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
         with:
           path: ${{ env.COMPOSER_CACHE_DIR }}
           key: php${{ matrix.php }}-composer-${{ hashFiles('**/composer.json') }}
@@ -110,6 +120,6 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.os == 'ubuntu-latest'
-        uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457
+        uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457 # v3.1.6
         with:
           files: ./coverage.xml

--- a/.github/workflows/pgsql.yml
+++ b/.github/workflows/pgsql.yml
@@ -22,6 +22,9 @@ on:
 
 name: pgsql
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: PHP ${{ matrix.php }}-pgsql-${{ matrix.pgsql }}
@@ -64,10 +67,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+        with:
+          persist-credentials: false
 
       - name: Install PHP with extensions
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45
         with:
           php-version: ${{ matrix.php }}
           extensions: ${{ env.extensions }}
@@ -80,7 +85,7 @@ jobs:
         run: echo "COMPOSER_CACHE_DIR=$(composer config cache-dir)" >> $GITHUB_ENV
 
       - name: Cache dependencies installed with composer
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c
         with:
           path: ${{ env.COMPOSER_CACHE_DIR }}
           key: php${{ matrix.php }}-composer-${{ hashFiles('**/composer.json') }}
@@ -105,6 +110,6 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.os == 'ubuntu-latest'
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457
         with:
           files: ./coverage.xml

--- a/.github/workflows/rector-cs.yml
+++ b/.github/workflows/rector-cs.yml
@@ -20,8 +20,5 @@ concurrency:
 jobs:
   rector:
     uses: yiisoft/actions/.github/workflows/rector-cs.yml@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
-    secrets:
-      token: ${{ secrets.YIISOFT_GITHUB_TOKEN }}
     with:
-      repository: ${{ github.event.pull_request.head.repo.full_name }}
       php: '8.1'

--- a/.github/workflows/rector-cs.yml
+++ b/.github/workflows/rector-cs.yml
@@ -20,8 +20,5 @@ concurrency:
 jobs:
   rector:
     uses: yiisoft/actions/.github/workflows/rector-cs.yml@master
-    secrets:
-      token: ${{ secrets.YIISOFT_GITHUB_TOKEN }}
     with:
-      repository: ${{ github.event.pull_request.head.repo.full_name }}
       php: '8.1'

--- a/.github/workflows/rector-cs.yml
+++ b/.github/workflows/rector-cs.yml
@@ -1,7 +1,7 @@
 name: Rector + PHP CS Fixer
 
 on:
-  pull_request_target:
+  pull_request:
     paths:
       - 'src/**'
       - 'tests/**'
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   rector:
-    uses: yiisoft/actions/.github/workflows/rector-cs.yml@master
+    uses: yiisoft/actions/.github/workflows/rector-cs.yml@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
     secrets:
       token: ${{ secrets.YIISOFT_GITHUB_TOKEN }}
     with:

--- a/.github/workflows/rector-cs.yml
+++ b/.github/workflows/rector-cs.yml
@@ -19,6 +19,6 @@ concurrency:
 
 jobs:
   rector:
-    uses: yiisoft/actions/.github/workflows/rector-cs.yml@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
+    uses: yiisoft/actions/.github/workflows/rector-cs.yml@master
     with:
       php: '8.1'

--- a/.github/workflows/sqlite.yml
+++ b/.github/workflows/sqlite.yml
@@ -21,6 +21,10 @@ on:
 
 name: sqlite
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -44,12 +48,12 @@ jobs:
 
     steps:
       - name: Checkout.
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           persist-credentials: false
 
       - name: Install PHP with extensions.
-        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           coverage: pcov
           extensions: pdo, pdo_sqlite
@@ -62,7 +66,7 @@ jobs:
         run: echo "COMPOSER_CACHE_DIR=$(composer config cache-dir)" >> $GITHUB_ENV
 
       - name: Cache dependencies installed with composer.
-        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
         with:
           path: ${{ env.COMPOSER_CACHE_DIR }}
           key: php${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
@@ -80,6 +84,6 @@ jobs:
 
       - name: Upload coverage to Codecov.
         if: matrix.os == 'ubuntu-latest'
-        uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457
+        uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457 # v3.1.6
         with:
           files: ./coverage.xml

--- a/.github/workflows/sqlite.yml
+++ b/.github/workflows/sqlite.yml
@@ -21,6 +21,9 @@ on:
 
 name: sqlite
 
+permissions:
+  contents: read
+
 jobs:
   phpunit:
     name: PHP ${{ matrix.php }}-${{ matrix.os }}
@@ -41,10 +44,12 @@ jobs:
 
     steps:
       - name: Checkout.
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+        with:
+          persist-credentials: false
 
       - name: Install PHP with extensions.
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45
         with:
           coverage: pcov
           extensions: pdo, pdo_sqlite
@@ -57,7 +62,7 @@ jobs:
         run: echo "COMPOSER_CACHE_DIR=$(composer config cache-dir)" >> $GITHUB_ENV
 
       - name: Cache dependencies installed with composer.
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c
         with:
           path: ${{ env.COMPOSER_CACHE_DIR }}
           key: php${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
@@ -75,6 +80,6 @@ jobs:
 
       - name: Upload coverage to Codecov.
         if: matrix.os == 'ubuntu-latest'
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457
         with:
           files: ./coverage.xml

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -22,9 +22,12 @@ on:
 
 name: static analysis
 
+permissions:
+  contents: read
+
 jobs:
   psalm:
-    uses: yiisoft/actions/.github/workflows/psalm.yml@master
+    uses: yiisoft/actions/.github/workflows/psalm.yml@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
     with:
       os: >-
         ['ubuntu-latest']

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   psalm:
-    uses: yiisoft/actions/.github/workflows/psalm.yml@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
+    uses: yiisoft/actions/.github/workflows/psalm.yml@master
     with:
       os: >-
         ['ubuntu-latest']

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -14,8 +14,8 @@ on:
       - '.github/**.yaml'
 
 permissions:
-  actions: read
-  contents: read
+  actions: read # Required by zizmor when reading workflow metadata through the API.
+  contents: read # Required to read workflow files.
 
 jobs:
   zizmor:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,37 @@
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+    push:
+        branches:
+            - main
+        paths:
+            - '.github/**.yml'
+            - '.github/**.yaml'
+    pull_request:
+        paths:
+            - '.github/**.yml'
+            - '.github/**.yaml'
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+permissions:
+    contents: read
+
+jobs:
+    zizmor:
+        name: Run zizmor 🌈
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  persist-credentials: false
+
+            - name: Run zizmor 🌈
+              uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+              with:
+                  advanced-security: false
+                  annotations: true
+                  persona: 'pedantic'

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,5 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        "yiisoft/*": any

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,5 +1,0 @@
-rules:
-  unpinned-uses:
-    config:
-      policies:
-        "yiisoft/*": any


### PR DESCRIPTION
## Summary
- Pin GitHub Actions and reusable Yii workflow references
- Restrict workflow token permissions to read-only contents where applicable
- Disable checkout credential persistence where it is not needed

## Validation
- zizmor --no-progress --no-exit-codes .github/workflows
- git diff --check